### PR TITLE
fix #9 - User 타입 정의, Identity Provider 정의

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -1,0 +1,35 @@
+package model
+
+import "time"
+
+type User struct {
+	Seq           int
+	Email         string
+	Name          string
+	Password      string
+	ProfileImgUrl string
+	Bio           string
+	IdProvider    IdentityProvider
+	RegisterDate  time.Time
+	UpdateDate    time.Time
+}
+
+type IdentityProvider int
+
+const (
+	Facebook IdentityProvider = 1 + iota
+	GooglePlus
+	Twitter
+	Self
+)
+
+var IdentityProviders = [...]string{
+	"Facebook",
+	"Google+",
+	"Twitter",
+	"Self",
+}
+
+func (idp IdentityProvider) String() string {
+	return IdentityProviders[idp-1]
+}

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cream-lab/vanilla/model"
+)
+
+func ExampleSetUser() {
+	user := model.User{
+		Seq:           1,
+		Email:         "luv4u525@gmail.com",
+		Name:          "Teddy",
+		ProfileImgUrl: "http://graph.facebook.com/686990364693854/picture?type=square",
+		Bio:           "I'm a developer",
+		IdProvider:    model.Facebook,
+		RegisterDate:  time.Now(),
+		UpdateDate:    time.Now(),
+	}
+
+	fmt.Println(user.IdProvider)
+
+	// Output: Facebook
+}


### PR DESCRIPTION
- 로그인 사용자 정보를 담을 타입 정의
- 페이스북, 구글+ 와 같은 인증 정보 제공자를 표현하기 위한 IdentityProvider 정의

페이스북과 같은 인증 정보 제공자를 통해 로그인 성공 시 관련 사용자 정보를 User 타입에 저장하여, 이를 DB나 파일같은 데이터 저장소에 저장한다.
